### PR TITLE
yb/add -Wl,-rpath and modidy the dipu_path and diopi_path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ def get_ext():
     extra_objects = []
     library_dirs = library_paths()
     libraries = ["c10", "torch", "torch_cpu", "torch_python"]
-    print(library_dirs)
     for i in library_dirs:
         extra_link_args = ['-Wl,-rpath,' + i]
 


### PR DESCRIPTION
1. add the -Wl,-rpath to fix the .so missing on the runtime, 
2. modify the dipu_root to dipu_path
3. modify the dipu_path and diopi_path to real dipu and diopi root directories.